### PR TITLE
Set the default .env location to the absolute path of the working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Usage
 
 The easiest and most common usage consists on calling `dotenv::dotenv` when the
 application starts, which will load environment variables from a file named
-`.env` located wherever your application binary is located; after that, you
-can just call the environment-related method you need as provided by `std::os`.
+`.env` in the root directory; after that, you can just call the
+environment-related method you need as provided by `std::os`.
 
 If you need finer control about the name of the file or its location, you can
 use the `from_filename` and `from_path` methods provided by the crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,10 @@ pub fn from_filename(filename: &str) -> Result<(), DotenvError> {
 /// dotenv::dotenv().ok();
 /// ```
 pub fn dotenv() -> Result<(), DotenvError> {
-    from_filename(concat!(env!("PWD"), "/.env"))
+    match env::current_dir() {
+       Ok(path) => from_path(path.join(".env").as_path()),
+       Err(_) => Err(DotenvError::Io),
+    }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub fn from_filename(filename: &str) -> Result<(), DotenvError> {
 /// dotenv::dotenv().ok();
 /// ```
 pub fn dotenv() -> Result<(), DotenvError> {
-    from_filename(".env")
+    from_filename(concat!(env!("PWD"), "/.env"))
 }
 
 #[test]


### PR DESCRIPTION
Using the PWD env var we should be able to set the env in the root directory.  I think this is a better default than where the executable file is.  What do you guys think?

Good work on the package by the way.  :smile: 