### PR TITLE
specify version range for regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-regex = "*"
+regex = "< 0.2"


### PR DESCRIPTION
Address #14 by limiting regex to versions less than 0.2 (the current version is 0.1.41).