### PR TITLE
Implement the `dotenv!` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ the environment-related method you need as provided by `std::os`.
 If you need finer control about the name of the file or its location, you can
 use the `from_filename` and `from_path` methods provided by the crate.
 
+`dotenv_codegen` and `dotenv_macros` also provide the `dotenv!` macro, which
+behaves identically to `env!`, but first tries to load a `.env` file at compile
+time.
+
 Examples
 ----
 
@@ -57,6 +61,59 @@ fn main() {
         println!("{}: {}", key, value);
     }
 }
+```
+
+Using the `dotenv!` macro on nightly
+------------------------------------
+
+Add `dotenv_macros` to your dependencies, and add `#![plugin(dotenv_macros)]` to
+the top of your crate.
+
+Using the `dotenv!` macro on stable
+-----------------------------------
+
+You can use `dotenv!` on stable using `syntex`. You'll need to add
+`dotenv_codegen` and `syntex` to your build dependencies.
+
+#### In `main.rs`:
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/main.rs"));
+```
+
+#### In `main.in.rs`:
+
+```rust
+fn main() {
+    println!("{}", &dotenv!("MEANING_OF_LIFE"));
+}
+```
+
+#### In `build.rs`:
+
+```rust
+extern crate syntex;
+extern crate dotenv_codegen;
+
+use std::env;
+use std::path::Path;
+
+pub fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let mut registry = syntex::Registry::new();
+    dotenv_codegen::register(&mut registry);
+
+    let src = Path::new("tests/main.in.rs");
+    let dst = Path::new(&out_dir).join("main.rs");
+
+    registry.expand("", &src, &dst).unwrap();
+}
+```
+
+#### In `.env`:
+
+```sh
+MEANING_OF_LIFE=42
 ```
 
 Issues

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dotenv_codegen"
+version = "0.1.0"
+authors = [
+    "Santiago Lapresta <santiago.lapresta@gmail.com>",
+    "Craig Hills <chills@gmail.com>",
+    "Mike Piccolo <mfpiccolo@gmail.com>",
+    "Alice Maz <alice@alicemaz.com>",
+]
+
+[build-dependencies]
+syntex = { version = "^0.22.0", optional = true }
+
+[dependencies]
+syntex = { version = "^0.22.0", optional = true }
+syntex_syntax = { version = "^0.22.0", optional = true }
+dotenv = "^0.6.0"
+
+[features]
+default = ["with-syntex"]
+with-syntex = ["syntex", "syntex_syntax"]

--- a/dotenv_codegen/src/dotenv_macro.rs
+++ b/dotenv_codegen/src/dotenv_macro.rs
@@ -1,0 +1,20 @@
+use dotenv::DotenvError::Parsing;
+use dotenv::dotenv;
+
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::ext::env::expand_env;
+
+pub fn expand_dotenv<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+                       -> Box<MacResult+'cx> {
+    match dotenv() {
+        Err(Parsing { line }) => {
+            cx.span_err(sp, &format!("Error parsing .env file: {}", line));
+            return DummyResult::expr(sp);
+        }
+        _ => {} // Either everything was fine, or we didn't find a .env file (which we ignore)
+    }
+    expand_env(cx, sp, tts)
+}
+

--- a/dotenv_codegen/src/lib.rs
+++ b/dotenv_codegen/src/lib.rs
@@ -1,0 +1,28 @@
+#![cfg_attr(not(feature = "with-syntex"), feature(rustc_private))]
+#![deny(warnings)]
+
+extern crate dotenv;
+
+#[cfg(feature = "with-syntex")]
+extern crate syntex;
+
+#[cfg(feature = "with-syntex")]
+extern crate syntex_syntax as syntax;
+
+#[cfg(not(feature = "with-syntex"))]
+extern crate syntax;
+
+#[cfg(not(feature = "with-syntex"))]
+extern crate rustc_plugin;
+
+mod dotenv_macro;
+
+#[cfg(feature = "with-syntex")]
+pub fn register(reg: &mut syntex::Registry) {
+    reg.add_macro("dotenv", dotenv_macro::expand_dotenv);
+}
+
+#[cfg(not(feature = "with-syntex"))]
+pub fn register(reg: &mut rustc_plugin::Registry) {
+    reg.register_macro("dotenv", dotenv_macro::expand_dotenv);
+}

--- a/dotenv_macros/Cargo.toml
+++ b/dotenv_macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dotenv_macros"
+version = "0.1.0"
+authors = [
+    "Santiago Lapresta <santiago.lapresta@gmail.com>",
+    "Craig Hills <chills@gmail.com>",
+    "Mike Piccolo <mfpiccolo@gmail.com>",
+    "Alice Maz <alice@alicemaz.com>",
+]
+
+[dependencies]
+dotenv_codegen = { version = "^0.1.0", default-features = false }
+
+[lib]
+name = "dotenv_macros"
+plugin = true

--- a/dotenv_macros/src/lib.rs
+++ b/dotenv_macros/src/lib.rs
@@ -1,0 +1,9 @@
+#![feature(rustc_private, plugin_registrar)]
+
+extern crate dotenv_codegen;
+extern crate rustc_plugin;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut rustc_plugin::Registry) {
+    dotenv_codegen::register(reg);
+}


### PR DESCRIPTION
The meat of this macro is absurdly simple, most of the code here is just
machinery for use on both stable and nighlty.

The macro is identical to the `env!` macro, but it calls
`dotenv::dotenv()` for you at compile time. If a `.env` file is found,
but fails to parse, the code will not compile. If a `.env` file is not
found, the behavior is simply that of `env!`, as `.env` files are meant
to be optional.

`dotenv_codegen` and `dotenv_macros` are separate crates, because we
need the format to be `rlib` on stable, but `dylib` on nightly
(specifying both can cause some weird issues when building downstream).

This doesn't include tests for the macro, as it would require jumping
through some hoops to get a simple test working, but I've tested this on
Diesel and it works great. A test can easily be added later.