### PR TITLE
Bump syntex (again)

### DIFF
--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dotenv_codegen"
-version = "0.7.2"
+version = "0.8.0"
 authors = [
   "Santiago Lapresta <santiago.lapresta@gmail.com>",
   "Craig Hills <chills@gmail.com>",
@@ -17,11 +17,11 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [build-dependencies]
-syntex = { version = "^0.25.0", optional = true }
+syntex = { version = ">= 0.24.0, < 0.27.0", optional = true }
 
 [dependencies]
-syntex = { version = "^0.25.0", optional = true }
-syntex_syntax = { version = "^0.25.0", optional = true }
+syntex = { version = ">= 0.24.0, < 0.27.0", optional = true }
+syntex_syntax = { version = ">= 0.24.0, < 0.27.0", optional = true }
 dotenv = "^0.7.2"
 
 [features]


### PR DESCRIPTION
I've loosened the constraints to a range, but ultimately that's not
terribly helpful since Cargo doesn't let you specify transitive
dependency versions, and it'll always resolve to the latest version. As
such, I've bumped the major here so that code depending on `^0.7.2`
will continue to compile.