### PR TITLE
Integrate Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: rust
+sudo: false
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cd tests
+  - cargo test --verbose


### PR DESCRIPTION
It's pretty common for Rust libraries to have CI testing. This will run both the tests in src/lib.rs as well as the ones in test/src/main.rs. Of course, someone will have to actually enable the integration on travis-ci.