### PR TITLE
Update codegen for breaking changes in libsyntax

### DIFF
--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dotenv_codegen"
-version = "0.8.1"
+version = "0.9.0"
 authors = [
   "Santiago Lapresta <santiago.lapresta@gmail.com>",
   "Craig Hills <chills@gmail.com>",
@@ -17,11 +17,11 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [build-dependencies]
-syntex = { version = ">= 0.24.0, < 0.32.0", optional = true }
+syntex = { version = ">= 0.37.0, < 0.39.0", optional = true }
 
 [dependencies]
-syntex = { version = ">= 0.24.0, < 0.32.0", optional = true }
-syntex_syntax = { version = ">= 0.24.0, < 0.32.0", optional = true }
+syntex = { version = ">= 0.37.0, < 0.39.0", optional = true }
+syntex_syntax = { version = ">= 0.37.0, < 0.39.0", optional = true }
 dotenv = "^0.8.0"
 
 [features]

--- a/dotenv_codegen/src/dotenv_macro.rs
+++ b/dotenv_codegen/src/dotenv_macro.rs
@@ -1,16 +1,16 @@
 use dotenv::DotenvError::Parsing;
 use dotenv::dotenv;
 
-use syntax::ast;
 use syntax::codemap::Span;
 use syntax::ext::base::*;
 use syntax::ext::base;
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
+use syntax::tokenstream;
 
 use std::env;
 
-pub fn expand_dotenv<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+pub fn expand_dotenv<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
                        -> Box<MacResult+'cx> {
     match dotenv() {
         Err(Parsing { line }) => {
@@ -22,7 +22,7 @@ pub fn expand_dotenv<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
     expand_env(cx, sp, tts)
 }
 
-fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[tokenstream::TokenTree])
     -> Box<base::MacResult>
 {
     let mut exprs = match get_exprs_from_tts(cx, sp, tts) {

--- a/dotenv_macros/Cargo.toml
+++ b/dotenv_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dotenv_macros"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
   "Santiago Lapresta <santiago.lapresta@gmail.com>",
   "Craig Hills <chills@gmail.com>",
@@ -17,7 +17,7 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-dotenv_codegen = { version = "^0.8.0", default-features = false }
+dotenv_codegen = { version = "0.9.0", default-features = false }
 
 [lib]
 name = "dotenv_macros"


### PR DESCRIPTION
@slapresta Just wanted to ping you before I merge/release this. We were affected by actual breakage, which means I need to bump the version of codegen and macros to 0.9.0. I know you had mentioned maybe wanting to keep them in sync, but I'd like to argue for separating them so that we don't have to bump the version on the main crate unnecessarily. Since codegen/macros are entirely dealt with at compile time, which version of dotenv they use underneath is actually not relevant, and can be separate from the application.