### PR TITLE
Bump regex to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-regex = "< 0.2"
+regex = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl From<std::io::Error> for DotenvError {
 type ParsedLine = Result<Option<(String, String)>, DotenvError>;
 
 fn named_string(captures: &Captures, name: &str) -> Option<String> {
-    captures.name(name).and_then(|v| Some(v.to_string()))
+    captures.name(name).and_then(|v| Some(v.as_str().to_owned()))
 }
 
 fn parse_value(input: &str) -> Result<String, DotenvError> {


### PR DESCRIPTION
The syntax changes in `regex 0.2` don't affect `rust-dotenv` which means this update is pretty straight-forward.
(closes #55)