### PR TITLE
Use error_chain/derive_error_chain for Error handling & transformation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,6 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
+derive-error-chain = "0.9.0"
+error-chain = "0.9.0"
 regex = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-derive-error-chain = "0.9.0"
-error-chain = "0.9.0"
+derive-error-chain = "0.10.0"
+error-chain = "0.10.0"
 regex = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ fn parse_value(input: &str) -> Result<String> {
             } else if c == '#' {
                 break;
             } else {
-                return Err(ErrorKind::LineParse(input.to_owned()).into());
+                bail!(ErrorKind::LineParse(input.to_owned()));
             }
         } else if strong_quote {
             if c == '\'' {
@@ -104,7 +104,7 @@ fn parse_value(input: &str) -> Result<String> {
                 //then there's \v \f bell hex... etc
                 match c {
                     '\\' | '"' | '$' => output.push(c),
-                    _ => return Err(ErrorKind::LineParse(input.to_owned()).into()),
+                    _ => bail!(ErrorKind::LineParse(input.to_owned())),
                 }
 
                 escaped = false;
@@ -119,7 +119,7 @@ fn parse_value(input: &str) -> Result<String> {
             if escaped {
                 match c {
                     '\\' | '\'' | '"' | '$' | ' ' => output.push(c),
-                    _ => return Err(ErrorKind::LineParse(input.to_owned()).into()),
+                    _ => bail!(ErrorKind::LineParse(input.to_owned())),
                 }
 
                 escaped = false;
@@ -131,7 +131,7 @@ fn parse_value(input: &str) -> Result<String> {
                 escaped = true;
             } else if c == '$' {
                 //variable interpolation goes here later
-                return Err(ErrorKind::LineParse(input.to_owned()).into());
+                bail!(ErrorKind::LineParse(input.to_owned()));
             } else if c == ' ' || c == '\t' {
                 expecting_end = true;
             } else {


### PR DESCRIPTION
This PR introduces a dependency on the [error_chain](https://crates.io/crates/error-chain) and [derive_error_chain](https://crates.io/crates/derive-error-chain) crates to implement Error handling. Basically, this just reduces some error-handling-related boilerplate.

The first patch in the PR is actually from @Nashenas88 #51 (sorry if inappropriate to include in my PR).

Obviously, this is really a "dependency choice" style change. If there is no interest in introducing this dependency, I would be interested in at least getting #51 merged as it does the actual work of improving downstream interaction with this crate.