### PR TITLE
Reference subcrates by path. Other minor changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ description = "A `dotenv` implementation for Rust"
 
 [dependencies]
 regex = "0.2.1"
+
+[workspace]
+members = ["dotenv_codegen", "dotenv_macros", "tests"]

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -22,7 +22,7 @@ syntex = { version = ">= 0.51.0, < 0.54.0", optional = true }
 [dependencies]
 syntex = { version = ">= 0.51.0, < 0.54.0", optional = true }
 syntex_syntax = { version = ">= 0.51.0, < 0.54.0", optional = true }
-dotenv = "^0.8.0"
+dotenv = { path = ".." }
 
 [features]
 default = ["with-syntex"]

--- a/dotenv_macros/Cargo.toml
+++ b/dotenv_macros/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/slapresta/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-dotenv_codegen = { version = "0.10.0", default-features = false }
+dotenv_codegen = { path = "../dotenv_codegen", default-features = false }
 
 [lib]
 name = "dotenv_macros"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["Mike Piccolo <mfpiccolo@gmail.com>"]
 
 [dependencies]
-dotenv = {path = "../"}
+dotenv = {path = ".."}
+dotenv_macros = { path = "../dotenv_macros" }

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(plugin)]
+#![plugin(dotenv_macros)]
 extern crate dotenv;
 
 use dotenv::*;
@@ -21,4 +23,9 @@ fn test_dotenv_child_dir() {
     assert_eq!("./main.rs".to_string(), path_string);
     dotenv().ok();
     assert_eq!(env::var("TESTKEY").unwrap(), "test_val");
+}
+
+#[test]
+fn test_dotenv_macro() {
+    assert_eq!(dotenv!("TESTKEY"), "test_val");
 }


### PR DESCRIPTION
- Reference subcrates by path instead of versions
- Test for `dotenv!` macro
- Workspace members